### PR TITLE
Fix diagonal map notation in rel.tex

### DIFF
--- a/rel/rel.tex
+++ b/rel/rel.tex
@@ -1513,7 +1513,7 @@ produce a \emph{pair} of real numbers if we have a single real number in hand?
 There are actually many ways one could proceed, but one reasonable choice is
 to create a pair where the input number appears in both coordinates.  This
 is the so-called \index{diagonal map}\emph{diagonal map}, 
-$d:\Reals \times \Reals \longrightarrow \Reals$, defined by $d(a) = (a,a)$.
+$d:\Reals \longrightarrow \Reals \times \Reals$, defined by $d(a) = (a,a)$.
 
 \begin{exer}
 Which of the following is always true,


### PR DESCRIPTION
Correctly specify the domain and codomain of the diagonal map, R -> RxR